### PR TITLE
fix git/pul-and-clean.sh

### DIFF
--- a/git/pull-and-clean.sh
+++ b/git/pull-and-clean.sh
@@ -44,7 +44,7 @@ cleanBranches() {
     && git -C $1 pull        > /dev/null 2>&1 \
     && git -C $1 fetch origin --prune \
     && git -C $1 branch -vv | egrep '\[origin/.*: gone\]' \
-       | awk '{print $1}' | egrep -v "(^\*|dev*|master*)" \
+       | awk '{print $1}' | egrep -v "(^\*|dev|master)" \
        | xargs --no-run-if-empty git -C $1 branch --delete --force
   return $?
 }


### PR DESCRIPTION
didn't delete some local branches containing `de` or `maste` due to wrong `*`