### PR TITLE
improve prepare-release for multi repos

### DIFF
--- a/maven/prepare-release.sh
+++ b/maven/prepare-release.sh
@@ -15,7 +15,10 @@ git checkout dev && git pull
 echo
 echo "Preparing release branch '${BRANCH}' ..."
 git branch ${BRANCH}
-git checkout ${BRANCH} && git merge dev && \
+git checkout ${BRANCH} && \
+(! git branch -r --contains ${BRANCH} &> /dev/null || \
+   git pull origin ${BRANCH}) && \
+git merge dev && \
 echo "... done" || die "unable to prepare branch ${BRANCH}"
 
 echo
@@ -50,6 +53,6 @@ read -p "Please check pom.xml, press enter to commit and push"
 echo
 echo "Commiting and pushing pom.xml ..."
 git add pom.xml && \
-git commit -m "update dependencies to latest releases" && \
-git push origin $BRANCH && \
+git commit -m "[prepare-release] update dependencies to latest releases" && \
+git push origin ${BRANCH} && \
 echo "... done" || echo "... FAILED"


### PR DESCRIPTION
the script fails if the local release branch already exists but is outdated, happens e.g. in multi repos after jenkins pushed release-commits to the same repo but we continue using the script on other projects within the repo. thus pull the release branch first if it exists on the origin repo.