### PR TITLE
Lineending keep and improving linebreaks in enums 

### DIFF
--- a/eclipse/synventis-code-formatter.xml
+++ b/eclipse/synventis-code-formatter.xml
@@ -66,7 +66,7 @@
         <setting
             id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions"
             value="do not insert" />
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0" />
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49" />
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1" />
         <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body"
             value="0" />

--- a/mvn/format-java.sh
+++ b/mvn/format-java.sh
@@ -42,7 +42,7 @@ JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | sed -E 's/^1\.//' | cut -d'.' -f1)
 
 mvn net.revelc.code.formatter:formatter-maven-plugin:2.23.0:format \
     -Dconfigfile="$FORMATTER_CONFIG" \
-    -Dlineending=LF \
+    -Dlineending=KEEP \
     -Dmaven.compiler.source="$JAVA_MAJOR_VERSION" \
     -Dmaven.compiler.target="$JAVA_MAJOR_VERSION" \
     -Dformatter.overrideConfigCompilerVersion=true \


### PR DESCRIPTION
### Suggestion from antigravity (CAUTION: may contain traces of AI :-D)
In `synventis-tools/eclipse/synventis-code-formatter.xml`, the setting controlling this is: `org.eclipse.jdt.core.formatter.alignment_for_enum_constants`

It was previously set to `0` ("Do not wrap"). Because the constants were on one line but exceeded the 100-character line limit, the formatter was forced to break the line somewhere else. It chose to break inside the enum arguments instead, since `org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant` allowed wrapping.

The Fix: I have changed `alignment_for_enum_constants `to `49`, which corresponds to **"Wrap all elements, every element on a new line"**.

This will force the formatter to treat the constants like this:
```
public enum TestEnum {
  OPENGRAPH_TITLE("og:title"),
  OPENGRAPH_TYPE("og:type"),
  // ... and so on
}
```

### Why 49?
In the Eclipse compiler (`org.eclipse.jdt.core.formatter`), alignment values are bitmasks that combine multiple layout rules into a single integer.

When configuring how sequences of items (like method arguments or enum constants) are formatted, Eclipse uses a 4-bit "wrap strategy" combined with a 1-bit "force flag". Here's the breakdown of where 49 comes from:

#### 1. The Strategy (48)
There are several base formatting strategies you can choose:

- `16 (WRAP_COMPACT)`: Wrap only when necessary, putting as many elements on a single line as possible without exceeding the max line length.
- `80 (WRAP_NEXT_PER_LINE)`: Wrap all elements, keeping the first element on the same line as the opening brace, but putting all subsequent elements on new lines.
- `48 (WRAP_ONE_PER_LINE)`: Wrap all elements, putting every single element on a new line.
Since we explicitly want every enum constant completely broken out into its own vertical list, the correct baseline strategy to pick is 48 (WRAP_ONE_PER_LINE).

#### 2. The Force Flag (+1)
In addition to the base strategy, Eclipse allows an optional "+1" flag called FORCE.

- If you **don't** add the 1 (so the value is just `48`), the formatter will only apply line breaks if the line exceeds the maximum line width.
- If you **do** add the 1 (so the value becomes `48 + 1 = 49`), it tells Eclipse: "I don't care how short this line is; FORCE every element onto a new line unconditionally.